### PR TITLE
fix: app-admin/1password - use stock desktop.

### DIFF
--- a/app-admin/1password/1password-8.10.33.ebuild
+++ b/app-admin/1password/1password-8.10.33.ebuild
@@ -51,8 +51,8 @@ EOF" >"${D}/usr/share/polkit-1/actions/com.1password.1Password.policy"
 
   dosym /opt/1Password/1password /usr/bin/1password
   dosym /opt/1Password/op-ssh-sign /usr/bin/op-ssh-sign
+  dosym /opt/1Password/resources/1password.desktop /usr/share/applications/1password.desktop
 
-  make_desktop_entry "${PN}" "1Password" "${PN}" "Office;Utility;"
   newicon "${D}/opt/1Password/resources/icons/hicolor/512x512/apps/1password.png" "${PN}.png"
 
   dodoc "${D}/opt/1Password/resources/custom_allowed_browsers"


### PR DESCRIPTION
I was having incredible difficulty with sso and 1password and tracked it down to this desktop file being out of spec with the one in the 1password package. I adjusted it on my end and this seems to work.